### PR TITLE
Use equals instead of is when comparing with literals

### DIFF
--- a/app/handlers.py
+++ b/app/handlers.py
@@ -17,7 +17,7 @@ def index():
 @app.route('/profile', defaults={ 'profile_id': -1 })
 @app.route('/profile/<profile_id>')
 def profile_user_stats(profile_id: int):
-    if profile_id is -1:
+    if profile_id == -1:
         return 'Handle default profile_id : )'
 
     profile_information_response = BlsPageHttp.get_profile_information(profile_id)

--- a/app/scraping/profile_page.py
+++ b/app/scraping/profile_page.py
@@ -43,7 +43,7 @@ class ProfilePage:
             # TODO: can't access by index, wonder why..
             stat_tds = tr.find_all('td', limit=2)
             for index, stat in enumerate(stat_tds, start=0):
-                if index is 1:
+                if index == 1:
                     stats.append(float(stat.text.replace(',', '.')))
 
         return stats


### PR DESCRIPTION
`is` compares memory address in Python so theoretically is shouldn't work, but Python caches small integers so that's why it works here. Anyway to make it bullet proof and remove warning from logs it's better to use double equals